### PR TITLE
Enable mount arguments in format HOST-DIR[:CONTAINER-DIR[:OPTIONS]]

### DIFF
--- a/src/rocker/mount_extension.py
+++ b/src/rocker/mount_extension.py
@@ -39,7 +39,11 @@ class Mount(RockerExtension):
 
     def get_docker_args(self, cli_args):
         args = ['']
-        for mount in cli_args['mount']:
+
+        # flatten cli_args['mount']
+        mounts = [ x for sublist in cli_args['mount'] for x in sublist]
+
+        for mount in mounts:
             elems = mount.split(':')
             host_dir = os.path.abspath(elems[0])
             if len(elems) == 1:
@@ -62,4 +66,5 @@ class Mount(RockerExtension):
             metavar='HOST-DIR[:CONTAINER-DIR[:OPTIONS]]',
             type=str,
             nargs='+',
+            action='append',
             help='mount volumes in container')


### PR DESCRIPTION
... without breaking the use case of mounting a directory from the host inside the container at the same location:
```sh
rocker --mount /path/to/workspace <image>
```

Note that the format is different from docker's `-v` option, which expects an argument in form `[[HOST-DIR:]CONTAINER-DIR[:OPTIONS]]`. A single entry without colons would be interpreted as a container directory and docker would create a new [anonymous volume](https://success.docker.com/article/different-types-of-volumes) mounted to that folder.

Extends https://github.com/osrf/rocker/pull/46.